### PR TITLE
Add Mysql Dependency As Docker Container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## CHANGELOG
+
+### 0.2.0
+
+* Add mysql orchestration via `Makefile` target

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## CHANGELOG
 
-### 0.2.0
+### 0.1.2
 
 * Add mysql orchestration via `Makefile` target

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,24 @@
+export PROJECT=dSilent
+export MYSQL_VERSION=8.0.14
+export MYSQL_PASSWORD=dSilent
+
 make:
 	pip install -r requirements.txt
+
+run: mysql
+
+
+mysql:
+	- docker volume create $(PROJECT)-mysql
+	- docker rm -f $(PROJECT)-mysql
+
+	docker run \
+		-d \
+		--rm \
+		--volume $(PROJECT)-mysql:/var/lib/mysql \
+		--env MYSQL_ROOT_PASSWORD=$(MYSQL_PASSWORD) \
+		--publish 3306:3306 \
+			mysql:$(MYSQL_VERSION)
+
+clean:
+	- docker volume rm -f $(PROJECT)-mysql

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ mysql:
 
 	docker run \
 		-d \
+		--name $(PROJECT)-mysql \
 		--rm \
 		--volume $(PROJECT)-mysql:/var/lib/mysql \
 		--env MYSQL_ROOT_PASSWORD=$(MYSQL_PASSWORD) \
@@ -21,4 +22,5 @@ mysql:
 			mysql:$(MYSQL_VERSION)
 
 clean:
+	- docker rm -f $(PROJECT)-mysql
 	- docker volume rm -f $(PROJECT)-mysql


### PR DESCRIPTION
## TICKET
NA

## NOTES
* Add mysql dependency as docker container
* Add makefile target `mysql` to manage container orchestration
* Add placeholder makefile target `run`
* Add Changelog

## TAGS
```bash
$ git ls-remote --tags
From git@github.com:sforsell/dSilent
9281d6e36f51b2e89388e5cd6f0ff18cdeea4c76	refs/tags/0.1.0
92fd1efaaa4fad09d8351f4efac7474197ffc8af	refs/tags/0.1.0^{}
2a0d5ec879764420cc2439647ae5dafd8bc6cf5e	refs/tags/0.1.1
6ee925c9d83e0defd6175447ef7bc135d07bdbb2	refs/tags/0.1.1^{}
```

## PROOFS

1\. Orchestrate mysql container.
```bash
$ make mysql
docker volume create dSilent-mysql
dSilent-mysql
docker rm -f dSilent-mysql
Error: No such container: dSilent-mysql
make: [mysql] Error 1 (ignored)
docker run \
		-d \
		--name dSilent-mysql \
		--rm \
		--volume dSilent-mysql:/var/lib/mysql \
		--env MYSQL_ROOT_PASSWORD=dSilent \
		--publish 3306:3306 \
			mysql:8.0.14
b34e4744e235c9187de458aef4a0151ce02a586e18b2cde413817ab2a77dd1fe
$ echo $?
0
```

2\. Use netcat to verify that port is open
```bash
$ nc -zv localhost 3306
found 0 associations
found 1 connections:
     1:	flags=82<CONNECTED,PREFERRED>
	outif lo0
	src ::1 port 53695
	dst ::1 port 3306
	rank info not available
	TCP aux info available

Connection to localhost port 3306 [tcp/mysql] succeeded!
```

3\. Use mysql client to list databases
```
$ mysql -h127.0.0.1 -uroot -pdSilent -e "show databases\G"
mysql: [Warning] Using a password on the command line interface can be insecure.
*************************** 1. row ***************************
Database: information_schema
*************************** 2. row ***************************
Database: mysql
*************************** 3. row ***************************
Database: performance_schema
*************************** 4. row ***************************
Database: sys
```
