### PR TITLE
Add Mysql Conf File To Set Bind Address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## CHANGELOG
 
+### 0.2.0
+
+* Add mysql configuration for bind-address
+
 ### 0.1.2
 
 * Add mysql orchestration via `Makefile` target

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ mysql:
 	docker run \
 		-d \
 		--name $(PROJECT)-mysql \
-		--rm \
 		--volume $(PROJECT)-mysql:/var/lib/mysql \
+		-v `pwd`/fsroot/etc/mysql/mysql.conf.d/bind.cnf:/etc/mysql/mysql.conf.d/bind.cnf:ro \
 		--env MYSQL_ROOT_PASSWORD=$(MYSQL_PASSWORD) \
 		--publish 3306:3306 \
 			mysql:$(MYSQL_VERSION)

--- a/fsroot/etc/mysql/mysql.conf.d/bind.cnf
+++ b/fsroot/etc/mysql/mysql.conf.d/bind.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+bind-address=0.0.0.0


### PR DESCRIPTION
## TICKET
NA

## Notes
- When running mysql container, connection from host fail because bind address is set to container eth interface/ip only
- Add `./fsroot/etc/mysql/mysql.conf.d/bind.cnf` with `bind-address=0.0.0.0`

## PROOFS

Exec into container, install netstat and view input side of socket bind
```bash
$ docker exec -it dSilent-mysql bash
$ apt update
...
$ apt install net-tools
...
$ netstat -nltpu | grep 3306
tcp        0      0 0.0.0.0:3306            0.0.0.0:*               LISTEN
```
