### PR TITLE
Add Make Target To Execute Arbitrary Command Within Make Context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## CHANGELOG
 
+### 0.3.0
+
+* Add target `command` to run arbitrary bash command within make context
+
 ### 0.2.0
 
 * Add mysql configuration for bind-address

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,16 @@
 export PROJECT=dSilent
 export MYSQL_VERSION=5.6
 export MYSQL_PASSWORD=dSilent
+ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
 
 make:
 	pip install -r requirements.txt
 
 run: mysql
 	python manage.py runserver
+
+command:
+	@ eval $(ARGS)
 
 mysql:
 	- docker volume create $(PROJECT)-mysql
@@ -24,3 +28,6 @@ mysql:
 clean:
 	- docker rm -f $(PROJECT)-mysql
 	- docker volume rm -f $(PROJECT)-mysql
+
+%:
+	@:


### PR DESCRIPTION
## TICKET
NA

## NOTES
* Add make target `command` to run arbitrary bash command within make context

## TAGS
```bash
$ git ls-remote --tags | grep -i 0\.3\.0
From git@github.com:sforsell/dSilent
37ec3ff6a11e56aa8bf011d65a7e1a40583c9059	refs/tags/0.3.0
cfcc864feb327697af7441f885f93e5491a568f8	refs/tags/0.3.0^{}
```


## PROOFS
```bash
# PROJECT is expected within makefile
$ make command echo \$PROJECT
dSilent
```
